### PR TITLE
Support checkout to a specific tag release

### DIFF
--- a/run_sandmark_backfill.py
+++ b/run_sandmark_backfill.py
@@ -54,6 +54,7 @@ parser.add_argument('--archive_dir', type=str, help='location to make archive (c
 parser.add_argument('--upload_project_name', type=str, help='specific upload project name (default is ocaml_<branch name>', default=None)
 parser.add_argument('--upload_date_tag', type=str, help='specific date tag to upload', default=None)
 parser.add_argument('--codespeed_url', type=str, help='codespeed URL for upload', default=CODESPEED_URL)
+parser.add_argument('--tag_commit', type=str, help="use specific tag release only", default=None)
 parser.add_argument('-v', '--verbose', action='store_true', default=False)
 
 args = parser.parse_args()
@@ -152,20 +153,24 @@ def check_archive_dir(d):
     return True
 archive_dirs = [f for f in archive_dirs if check_archive_dir(f)]
 
-## generate list of hash commits
-hashes = git_hashes.get_git_hashes(args)
+hashes = []
 
-if args.incremental_hashes:
-    def check_hash_new(h):
-        hash_dir = os.path.join(outdir, h)
-        hash_already_run = os.path.exists(hash_dir)
-        if args.verbose and hash_already_run:
-            print('Found results at %s skipping rerun'%hash_dir)
-        return not hash_already_run
+if args.tag_commit is None:
+	## generate list of hash commits
+	hashes = git_hashes.get_git_hashes(args)
 
-    hashes = [h for h in hashes if check_hash_new(h)]
+	if args.incremental_hashes:
+		def check_hash_new(h):
+			hash_dir = os.path.join(outdir, h)
+			hash_already_run = os.path.exists(hash_dir)
+			if args.verbose and hash_already_run:
+				print('Found results at %s skipping rerun'%hash_dir)
+				return not hash_already_run
 
-hashes = hashes[-args.max_hashes:]
+	hashes = [h for h in hashes if check_hash_new(h)]
+	hashes = hashes[-args.max_hashes:]
+else:
+	hashes = [args.tag_commit]
 
 if args.verbose:
     print('Found %d hashes using %s to do %s on'%(len(hashes), args.commit_choice_method, args.run_stages))


### PR DESCRIPTION
The `OCaml version mismatch: 4.09.1, expected 4.09.0` error shows up because OCaml trunk uses 4.09 branch to keep track of all updates to 4.09.1, 4.09.2 etc. by just bumping the version in the VERSION file. A sample example of version number changes is as follows:
```
4.09.2+dev0-2020-03-13
4.09.1
4.09.1+dev1-2020-03-13
4.09.1+dev0
4.09.0
4.09.0+dev7-2019-09-17
4.09.0+dev6-2019-09-11
...
The get_git_hashes() function in get_git_hashes.py script checks out the 4.09 branch, and we end up having the latest changes, instead of a specific revision. Hence, this patch accepts a `--tag-commit` option that is to match a specific tagged release to be checked out.

Note: The .yaml file in ocaml-bench-config MUST have `tag_commit : ""` if this feature is not to be used for a specific entry.