### PR TITLE
Filter OCaml mismatch error hashes

### DIFF
--- a/git_hashes.py
+++ b/git_hashes.py
@@ -133,7 +133,8 @@ def get_git_hashes(args):
 
 	hashes = [ h for h in hashes if h ] # filter any null hashes
 
-	hashes = [h for h in hashes if check_ocaml_version_mismatch(args.sandmark_tag_override, h)]
+	if args.sandmark_tag_override:
+		hashes = [h for h in hashes if check_ocaml_version_mismatch(args.sandmark_tag_override, h)]
 
 	os.chdir(old_cwd)
 	return hashes

--- a/run_backfill.py
+++ b/run_backfill.py
@@ -47,6 +47,7 @@ parser.add_argument('-j', '--jobs', type=int, help='number of concurrent jobs du
 parser.add_argument('-v', '--verbose', action='store_true', default=False)
 
 args = parser.parse_args()
+args.sandmark_tag_override = None
 
 def shell_exec(cmd, verbose=args.verbose, check=False, stdout=None, stderr=None):
 	if verbose:

--- a/run_sandmark_backfill.py
+++ b/run_sandmark_backfill.py
@@ -132,6 +132,15 @@ def parse_and_format_results_for_upload(fname, artifacts_timestamp):
 
     return upload_data
 
+def find_ocaml_version(args, h):
+    old_cwd = os.getcwd()
+    repo_url = args.sandmark_comp_fmt.split('/')
+    user_repo = repo_url[3] + '__' +  repo_url[4] # ocaml__ocaml
+    source_dir = os.path.join(os.path.abspath(SCRIPTDIR), user_repo)
+    os.chdir(source_dir)
+    proc_output = shell_exec('git show %s:VERSION | head -1' % (h), stdout=subprocess.PIPE)
+    os.chdir(old_cwd)
+    return proc_output.stdout.decode('utf-8').split('\n')[0]
 
 run_timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
 
@@ -182,8 +191,7 @@ for h in hashes:
     if args.sandmark_tag_override:
         full_branch_tag = args.sandmark_tag_override
     else:
-	## TODO: we need to somehow get the '.0' more correctly
-        full_branch_tag = '%s.0'%args.branch
+        full_branch_tag = find_ocaml_version(args, h)
     if executable_variant:
         full_branch_tag += '+' + executable_variant
     version_tag = os.path.join('ocaml-versions', full_branch_tag)

--- a/sandmark_batch_generator.py
+++ b/sandmark_batch_generator.py
@@ -52,7 +52,6 @@ GITHUB_USER={github_user}
 GITHUB_REPO={github_repo}
 BRANCH={branch}
 FIRST_COMMIT={first_commit}
-TAG_COMMIT={tag_commit}
 MAX_HASHES={max_hashes}
 OCAML_VERSION={ocaml_version}
 RUN_PATH_TAG={run_path_tag}
@@ -84,20 +83,13 @@ cd $SCRIPTDIR
 REPO=${GITHUB_USER}__${GITHUB_REPO}
 if [ ! -d ${REPO} ]; then
 	git clone https://github.com/${GITHUB_USER}/${GITHUB_REPO}.git ${REPO}
-    if [ ! -z ${TAG_COMMIT} ]; then
-        cd ${REPO}; git reset --hard ${TAG_COMMIT}; cd ${SCRIPTDIR}
-    fi
 fi
 
 ## setup target codespeed db to see project
 sqlite3 ${CODESPEED_DB} "INSERT INTO codespeed_project (name,repo_type,repo_path,repo_user,repo_pass,commit_browsing_url,track,default_branch) SELECT '${CODESPEED_NAME}', 'G', 'https://github.com/${GITHUB_USER}/${GITHUB_REPO}', '${GITHUB_USER}', '', 'https://github.com/${GITHUB_USER}/${GITHUB_REPO}/commit/{commitid}',1,'${BRANCH}' WHERE NOT EXISTS(SELECT 1 FROM codespeed_project WHERE name = '${CODESPEED_NAME}')"
 
 ## run backfill script
-if [ ! -z ${TAG_COMMIT} ]; then
-    ./run_sandmark_backfill.py --run_stages ${RUN_STAGES} --branch ${BRANCH} --main_branch ${BRANCH} --repo ${REPO} --repo_pull --repo_reset_hard --use_repo_reference --max_hashes ${MAX_HASHES} --incremental_hashes --commit_choice_method from_hash=${FIRST_COMMIT} --executable_spec=${EXEC_SPEC} --environment ${ENVIRONMENT} --sandmark_comp_fmt https://github.com/${GITHUB_USER}/${GITHUB_REPO}/archive/{tag}.tar.gz --sandmark_tag_override ${OCAML_VERSION} --tag_commit ${TAG_COMMIT} --sandmark_iter 1 --sandmark_pre_exec="'taskset --cpu-list "${BENCH_CORE}" setarch `uname -m` --addr-no-randomize'" --sandmark_run_bench_targets ${BENCH_TARGETS} --archive_dir ${ARCHIVE_DIR} --codespeed_url ${CODESPEED_URL} --upload_project_name ${CODESPEED_NAME} -v ${RUNDIR}
-else
-    ./run_sandmark_backfill.py --run_stages ${RUN_STAGES} --branch ${BRANCH} --main_branch ${BRANCH} --repo ${REPO} --repo_pull --repo_reset_hard --use_repo_reference --max_hashes ${MAX_HASHES} --incremental_hashes --commit_choice_method from_hash=${FIRST_COMMIT} --executable_spec=${EXEC_SPEC} --environment ${ENVIRONMENT} --sandmark_comp_fmt https://github.com/${GITHUB_USER}/${GITHUB_REPO}/archive/{tag}.tar.gz --sandmark_tag_override ${OCAML_VERSION} --sandmark_iter 1 --sandmark_pre_exec="'taskset --cpu-list "${BENCH_CORE}" setarch `uname -m` --addr-no-randomize'" --sandmark_run_bench_targets ${BENCH_TARGETS} --archive_dir ${ARCHIVE_DIR} --codespeed_url ${CODESPEED_URL} --upload_project_name ${CODESPEED_NAME} -v ${RUNDIR}
-fi
+./run_sandmark_backfill.py --run_stages ${RUN_STAGES} --branch ${BRANCH} --main_branch ${BRANCH} --repo ${REPO} --repo_pull --repo_reset_hard --use_repo_reference --max_hashes ${MAX_HASHES} --incremental_hashes --commit_choice_method from_hash=${FIRST_COMMIT} --executable_spec=${EXEC_SPEC} --environment ${ENVIRONMENT} --sandmark_comp_fmt https://github.com/${GITHUB_USER}/${GITHUB_REPO}/archive/{tag}.tar.gz --sandmark_tag_override ${OCAML_VERSION} --sandmark_iter 1 --sandmark_pre_exec="'taskset --cpu-list "${BENCH_CORE}" setarch `uname -m` --addr-no-randomize'" --sandmark_run_bench_targets ${BENCH_TARGETS} --archive_dir ${ARCHIVE_DIR} --codespeed_url ${CODESPEED_URL} --upload_project_name ${CODESPEED_NAME} -v ${RUNDIR}
 
 '''
 


### PR DESCRIPTION
The PR now compares OCAML_VERSION provided as input in the .yml file with the version specified in the VERSION file for a list of commits, and only runs the stages for the hashes that satisfy the ocaml-base-compiler version. So, a "4.09.2+dev0-2020-03-13" in the VERSION file will only match a user input of "4.09.2". This is a strict rule that is enforced by opam.

We no longer need the tag_commit, and this is removed from the code.