### PR TITLE
Added scripts for Navajo crontab run executions

### DIFF
--- a/crontab_run_sandmark_navajo_custom.sh
+++ b/crontab_run_sandmark_navajo_custom.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# log to the scratch dir
+#TIMESTAMP=`date +'%Y%m%d_%H%M%S'`
+TIMESTAMP=`date +'%Y%m%d_%H%M'`
+SCRATCHDIR=/local/scratch/sandmark/daily
+
+RUNDIR=${SCRATCHDIR}/${TIMESTAMP}
+LOGFILE=${RUNDIR}/logfile_${TIMESTAMP}.log
+mkdir -p $RUNDIR
+
+echo "Redirecting stdout/stderr to $LOGFILE"
+
+# setup logfile and redirect our stdout and stderr to this file
+touch $LOGFILE
+exec 1> $LOGFILE
+exec 2>&1
+
+echo "Processing in ${RUNDIR}"
+
+# don't allow unset variables
+set -o nounset
+
+# be verbose as we execute
+set -x
+
+# needed to get the path to include a dune binary
+# NB: a full eval $(opam config env) breaks the sandmark build in a strange way...
+eval $(opam config env | grep ^PATH=)
+
+# make sure python log files are in order
+PYTHONUNBUFFERED=true
+
+# run custom daily runs
+cd /home/sandmark/production/ocaml-bench-config
+./daily_run_navajo_custom.sh navajo.ocamllabs.io_custom.yml

--- a/crontab_run_sandmark_navajo_prod.sh
+++ b/crontab_run_sandmark_navajo_prod.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# log to the scratch dir
+#TIMESTAMP=`date +'%Y%m%d_%H%M%S'`
+TIMESTAMP=`date +'%Y%m%d_%H%M'`
+SCRATCHDIR=/local/scratch/sandmark/daily
+
+RUNDIR=${SCRATCHDIR}/${TIMESTAMP}
+LOGFILE=${RUNDIR}/logfile_${TIMESTAMP}.log
+mkdir -p $RUNDIR
+
+echo "Redirecting stdout/stderr to $LOGFILE"
+
+# setup logfile and redirect our stdout and stderr to this file
+touch $LOGFILE
+exec 1> $LOGFILE
+exec 2>&1
+
+echo "Processing in ${RUNDIR}"
+
+# don't allow unset variables
+set -o nounset
+
+# be verbose as we execute
+set -x
+
+# needed to get the path to include a dune binary
+# NB: a full eval $(opam config env) breaks the sandmark build in a strange way...
+eval $(opam config env | grep ^PATH=)
+
+# make sure python log files are in order
+PYTHONUNBUFFERED=true
+
+# run custom daily runs
+cd /home/sandmark/production/ocaml-bench-config
+./daily_run_navajo_prod.sh navajo.ocamllabs.io_prod.yml
+

--- a/run_sandmark_backfill.py
+++ b/run_sandmark_backfill.py
@@ -205,11 +205,12 @@ for h in hashes:
         else:
             ## setup sandmark (make a clone and change the hash)
             shell_exec('git clone --reference %s %s %s'%(args.sandmark_repo, args.sandmark_repo, sandmark_dir))
-            comp_file = os.path.join(sandmark_dir, '%s.comp'%version_tag)
+            comp_file = os.path.join(sandmark_dir, '%s.json' % version_tag)
+            json_url = {'url': args.sandmark_comp_fmt.format(**{'tag': h})}
             if args.verbose:
                 print('writing hash information to: %s'%comp_file)
             with open(comp_file, 'w') as f:
-                f.write(args.sandmark_comp_fmt.format(**{'tag': h}))
+                json.dump(json_url, f)
 
     if 'bench' in args.run_stages:
         ## run bench


### PR DESCRIPTION
The PR:
* Provides two bash scripts for running the serial benchmarks on navajo server for the production and custom branch runs.
* Since, we now use JSON for ocaml-versions/* in Sandmark, the `run_sandmark_backfill.py` script has been updated to create a JSON file with the URL.