### PR TITLE
Add support for parallel multibench targets and JSON input

### DIFF
--- a/run_sandmark_backfill.py
+++ b/run_sandmark_backfill.py
@@ -22,6 +22,8 @@ DEFAULT_MAIN_BRANCH = 'trunk'
 SANDMARK_REPO = os.path.join(SCRIPTDIR, 'sandmark')
 SANDMARK_COMP_FMT_DEFAULT = 'https://github.com/ocaml/ocaml/archive/{tag}.tar.gz'
 SANDMARK_RUN_BENCH_TARGETS_DEFAULT = 'run_orun'
+SANDMARK_RUN_JSON_DEFAULT = 'run_config.json'
+SANDMARK_BUILD_BENCH_TARGET_DEFAULT = 'buildbench'
 CODESPEED_URL = 'http://localhost:8000/'
 ENVIRONMENT = 'macbook'
 
@@ -55,6 +57,8 @@ parser.add_argument('--upload_project_name', type=str, help='specific upload pro
 parser.add_argument('--upload_date_tag', type=str, help='specific date tag to upload', default=None)
 parser.add_argument('--configure_options', type=str, help='configure options to compiler', default='')
 parser.add_argument('--ocamlrunparam', type=str, help='OCAMLRUNPARAM', default='')
+parser.add_argument('--run_json', type=str, help='Run JSON', default=SANDMARK_RUN_JSON_DEFAULT)
+parser.add_argument('--build_bench_target', type=str, help='Build Bench Target', default=SANDMARK_BUILD_BENCH_TARGET_DEFAULT)
 parser.add_argument('--codespeed_url', type=str, help='codespeed URL for upload', default=CODESPEED_URL)
 parser.add_argument('-v', '--verbose', action='store_true', default=False)
 
@@ -216,6 +220,8 @@ for h in hashes:
                 print('writing hash information to: %s'%comp_file)
             with open(comp_file, 'w') as f:
                 json.dump(json_contents, f)
+        if args.run_json:
+                shell_exec('cd %s; make %s'%(sandmark_dir, args.run_json))
 
     if 'bench' in args.run_stages:
         ## run bench
@@ -229,7 +235,7 @@ for h in hashes:
                 print('Running bench target %s'%target)
 
             log_fname = os.path.join(hashdir, '%s_%s.log'%(run_timestamp, target))
-            completed_proc = shell_exec_redirect('cd %s; make %s.bench ITER=%i PRE_BENCH_EXEC=%s RUN_BENCH_TARGET=%s'%(sandmark_dir, version_tag, args.sandmark_iter, args.sandmark_pre_exec, target), log_fname)
+            completed_proc = shell_exec_redirect('cd %s; make %s.bench ITER=%i PRE_BENCH_EXEC=%s RUN_BENCH_TARGET=%s BUILD_BENCH_TARGET=%s RUN_CONFIG_JSON=%s'%(sandmark_dir, version_tag, args.sandmark_iter, args.sandmark_pre_exec, target, args.build_bench_target, args.run_json), log_fname)
             if completed_proc.returncode != 0:
                 print('ERROR[%d] in sandmark bench run for %s (see %s)'%(completed_proc.returncode, h, log_fname))
                 ## TODO: the error isn't fatal, just that something failed in there...

--- a/sandmark_batch_generator.py
+++ b/sandmark_batch_generator.py
@@ -46,10 +46,12 @@ SCRATCHDIR={scratchdir}
 
 BENCH_TARGETS={bench_targets}
 BENCH_CORE={bench_core}
+BUILD_BENCH_TARGET={build_bench_target}
 ENVIRONMENT={environment}
 EXEC_SPEC={exec_spec}
 CODESPEED_URL={codespeed_url}
 CODESPEED_DB={ocamlspeed_dir}/data/data.db
+RUN_JSON={run_json}
 ARCHIVE_DIR={ocamlspeed_dir}/artifacts/
 
 GITHUB_USER={github_user}
@@ -95,7 +97,7 @@ fi
 sqlite3 ${CODESPEED_DB} "INSERT INTO codespeed_project (name,repo_type,repo_path,repo_user,repo_pass,commit_browsing_url,track,default_branch) SELECT '${CODESPEED_NAME}', 'G', 'https://github.com/${GITHUB_USER}/${GITHUB_REPO}', '${GITHUB_USER}', '', 'https://github.com/${GITHUB_USER}/${GITHUB_REPO}/commit/{commitid}',1,'${BRANCH}' WHERE NOT EXISTS(SELECT 1 FROM codespeed_project WHERE name = '${CODESPEED_NAME}')"
 
 ## run backfill script
-./run_sandmark_backfill.py --run_stages ${RUN_STAGES} --branch ${BRANCH} --main_branch ${BRANCH} --repo ${REPO} --repo_pull --repo_reset_hard --use_repo_reference --max_hashes ${MAX_HASHES} --incremental_hashes --commit_choice_method from_hash=${FIRST_COMMIT} --executable_spec=${EXEC_SPEC} --environment ${ENVIRONMENT} --sandmark_comp_fmt https://github.com/${GITHUB_USER}/${GITHUB_REPO}/archive/{tag}.tar.gz --sandmark_tag_override ${OCAML_VERSION} --sandmark_iter 1 --sandmark_pre_exec="'taskset --cpu-list "${BENCH_CORE}" setarch `uname -m` --addr-no-randomize'" --sandmark_run_bench_targets ${BENCH_TARGETS} --archive_dir ${ARCHIVE_DIR} --codespeed_url ${CODESPEED_URL} --configure_options="${CONFIGURE_OPTIONS}" --ocamlrunparam="${OCAMLRUNPARAM}" --upload_project_name ${CODESPEED_NAME} -v ${RUNDIR}
+./run_sandmark_backfill.py --run_stages ${RUN_STAGES} --branch ${BRANCH} --main_branch ${BRANCH} --repo ${REPO} --repo_pull --repo_reset_hard --use_repo_reference --max_hashes ${MAX_HASHES} --incremental_hashes --commit_choice_method from_hash=${FIRST_COMMIT} --executable_spec=${EXEC_SPEC} --environment ${ENVIRONMENT} --sandmark_comp_fmt https://github.com/${GITHUB_USER}/${GITHUB_REPO}/archive/{tag}.tar.gz --sandmark_tag_override ${OCAML_VERSION} --sandmark_iter 1 --sandmark_pre_exec="'taskset --cpu-list "${BENCH_CORE}" setarch `uname -m` --addr-no-randomize'" --sandmark_run_bench_targets ${BENCH_TARGETS} --archive_dir ${ARCHIVE_DIR} --codespeed_url ${CODESPEED_URL} --configure_options="${CONFIGURE_OPTIONS}" --ocamlrunparam="${OCAMLRUNPARAM}" --run_json ${RUN_JSON} --build_bench_target ${BUILD_BENCH_TARGET} --upload_project_name ${CODESPEED_NAME} -v ${RUNDIR}
 
 '''
 


### PR DESCRIPTION
A couple of variables are now included from Sandmark for executing parallel benchmarks:
* RUN_JSON: The parallel JSON file to be created prior to running the benchmark can be specified in the .yml configuration file.
* BUILD_BENCH_TARGET: The `multibench_parallel` value is used to install the required dependencies for the parallel execution runs.
The patch adds support to these new variables, and also defines defaults for the serial benchmarks.